### PR TITLE
Added reference to Eclipse RDF4J

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of resources for graph databases and graph computing tools
 
 * [AllegroGraph](https://franz.com/agraph/allegrograph/) - high-performance, persistent graph database that scales to billions of quads
 * [Apache Jena](https://jena.apache.org/) - open source Java framework for building Semantic Web and Linked Data applications
+* [Eclipse RDF4J](http://rdf4j.org/) - (formerly known as Sesame) is an open source Java framework for processing RDF data. This includes parsing, storing, inferencing and querying of/over such data. It offers an easy-to-use API that can be connected to all leading RDF storage solutions. It allows you to connect with SPARQL endpoints and create applications that leverage the power of linked data and Semantic Web.
 * [GraphDB](http://graphdb.ontotext.com/graphdb/) - enterprise ready Semantic Graph Database, compliant with W3C Standards
 * [Virtuoso](https://virtuoso.openlinksw.com/) - a "Data Junction Box" that drives enterprise and individual agility by deriving a Semantic Web of Linked Data from existing data silos
 


### PR DESCRIPTION
Eclipse RDF4J (formerly known as Sesame) is another widely used RDF framework for Java.

I added the first paragraph of description from the RDF4J page. If this is too long, we can basically use the same description as for Apache Jena (but I would keep the Sesame reference, as this is widely known)