### PR TITLE
Added JanusGraph on GCP with Cloud Bigtable backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A curated list of resources for graph databases and graph computing tools
 * [CosmosDB @ Microsoft](https://docs.microsoft.com/en-us/azure/cosmos-db/graph-introduction)
 * [IBM Graph @ IBM Bluemix](https://console.ng.bluemix.net/catalog/services/ibm-graph/) - OLTP graph database as a service.
 * [JanusGraph @ IBM Compose](https://www.compose.com/databases/janusgraph)
+* [JanusGraph @ Google Cloud Platform](https://cloud.google.com/solutions/running-janusgraph-with-bigtable) - JanusGraph on Google Kubernetes Engine backed by Google Cloud Bigtable
 * [JanusGraph @ Amazon Web Services Labs](https://github.com/awslabs/dynamodb-janusgraph-storage-backend)
 * [Neo4j @ Graphene](https://www.graphenedb.com/)
 * [Neptune @ Amazon Web Services](https://aws.amazon.com/neptune/) - a fast, reliable, fully-managed graph database service that makes it easy to build and run applications that work with highly connected datasets

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ A curated list of resources for graph databases and graph computing tools
 ## Managed hosting services
 
 * [CosmosDB @ Microsoft](https://docs.microsoft.com/en-us/azure/cosmos-db/graph-introduction)
-* [IBM Graph @ IBM Bluemix](https://console.ng.bluemix.net/catalog/services/ibm-graph/) - OLTP graph database as a service.
 * [JanusGraph @ IBM Compose](https://www.compose.com/databases/janusgraph)
 * [JanusGraph @ Google Cloud Platform](https://cloud.google.com/solutions/running-janusgraph-with-bigtable) - JanusGraph on Google Kubernetes Engine backed by Google Cloud Bigtable
 * [JanusGraph @ Amazon Web Services Labs](https://github.com/awslabs/dynamodb-janusgraph-storage-backend)


### PR DESCRIPTION
Also removed IBM Graph, as it was replaced by IBM Compose for JanusGraph.